### PR TITLE
fixed: changed param on notify_user from null to array

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -104,7 +104,7 @@ function account_removal_send_notification($type, $user_guid) {
 		$url,
 	]);
 	
-	notify_user($user_guid, $site->getGUID(), $subject, $message, null, 'email');
+	notify_user($user_guid, $site->getGUID(), $subject, $message, [], 'email');
 	
 	return true;
 }
@@ -138,7 +138,7 @@ function account_removal_send_thank_notification($type, $user_guid) {
 		$site->name,
 	]);
 	
-	notify_user($user_guid, $site->getGUID(), $subject, $message, null, 'email');
+	notify_user($user_guid, $site->getGUID(), $subject, $message, [], 'email');
 	
 	return true;
 }


### PR DESCRIPTION
Due to error:
Exception at time 1497107906: TypeError: Argument 5 passed to notify_user() must be of the type array, null given, called in /var/www/xxx/mod/account_removal/lib/functions.php on line 107 and defined in /var/www/xxx/vendor/elgg/elgg/engine/lib/notification.php:488