### PR TITLE
fix: add missing namespaces

### DIFF
--- a/elgg-plugin.php
+++ b/elgg-plugin.php
@@ -1,4 +1,6 @@
 <?php
+use ColdTrick\AccountRemoval\Bootstrap;
+
 require_once __DIR__ . '/lib/functions.php';
 
 return [


### PR DESCRIPTION
Adding the ColdTrick\AccountRemoval\Bootstrap namespace in elgg-plugin.php